### PR TITLE
launch processes with ordinary values for PATH and DYLD_ROOT_PATH, like instruments does

### DIFF
--- a/ScriptAgentShim/ScriptAgentShim/ScriptAgentShim.m
+++ b/ScriptAgentShim/ScriptAgentShim/ScriptAgentShim.m
@@ -80,17 +80,6 @@ static NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task) {
   [task setStandardOutput:stdoutPipe];
   [task setStandardError:stderrPipe];
   
-  NSMutableDictionary *environment = [[NSMutableDictionary alloc] initWithDictionary:[[NSProcessInfo processInfo] environment]];
-  NSString *path = [[NSString stringWithContentsOfFile:@"/etc/paths"
-                                              encoding:NSUTF8StringEncoding
-                                                 error:NULL]
-                          stringByReplacingOccurrencesOfString:@"\n"
-                                                    withString:@":"];
-  [environment setObject:path
-                  forKey:@"PATH"];
-  [environment removeObjectForKey:@"DYLD_ROOT_PATH"];
-  [task setEnvironment:environment];
-
   [task launch];
   [task waitUntilExit];
   
@@ -123,6 +112,17 @@ static id UIAHost_performTaskWithpath(id self, SEL cmd, id path, id arguments, i
   [task setLaunchPath:path];
   [task setArguments:arguments];
   
+  NSMutableDictionary *environment = [[[NSMutableDictionary alloc] initWithDictionary:[[NSProcessInfo processInfo] environment]] autorelease];
+  NSString *envpath = [[NSString stringWithContentsOfFile:@"/etc/paths"
+                                                 encoding:NSUTF8StringEncoding
+                                                    error:NULL]
+                          stringByReplacingOccurrencesOfString:@"\n"
+                                                    withString:@":"];
+  [environment setObject:envpath
+                  forKey:@"PATH"];
+  [environment removeObjectForKey:@"DYLD_ROOT_PATH"];
+  [task setEnvironment:environment];
+
   NSDictionary *output = LaunchTaskAndCaptureOutput(task);
   
   id result = @{@"exitCode": @([task terminationStatus]),


### PR DESCRIPTION
This makes instruments-without-delay more closely match the behavior of instruments. We needed this to make it work for Appium (https://github.com/appium/appium), which launches some programs from /usr/bin and others that use regular system shared libraries.

instruments-without-delay is awesome, by the way. Thanks for building this!
