### PR TITLE
Build ScriptAgentShim.dylib as a universal binary.

### DIFF
--- a/Configurations/iOS-Simulator-Dylib.xcconfig
+++ b/Configurations/iOS-Simulator-Dylib.xcconfig
@@ -38,8 +38,8 @@ SDKROOT = macosx
 // OSX specific flags.
 LD = ../Configurations/ld_dont_link_as_osx.py
 
-ARCHS = i386
-VALID_ARCHS = i386
+ARCHS = i386 x86_64
+VALID_ARCHS = i386 x86_64
 
 // -fobjc-abi-version=2
 //    Forces the ObjC 2.0 ABI.  You wouldn't normally set this for an OS X dylib as it's already

--- a/ScriptAgentShim/ScriptAgentShim.xcodeproj/project.pbxproj
+++ b/ScriptAgentShim/ScriptAgentShim.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 			baseConfigurationReference = 2862844F16DD5D6000EE287B /* ScriptAgentShim.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -173,6 +174,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Debug;
 		};
@@ -181,6 +183,7 @@
 			baseConfigurationReference = 2862844F16DD5D6000EE287B /* ScriptAgentShim.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -197,6 +200,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Release;
 		};
@@ -204,10 +208,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2862844F16DD5D6000EE287B /* ScriptAgentShim.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = ScriptAgentShim;
+				"VALID_ARCHS[sdk=iphoneos7.0]" = x86_64;
 			};
 			name = Debug;
 		};
@@ -215,10 +222,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2862844F16DD5D6000EE287B /* ScriptAgentShim.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = ScriptAgentShim;
+				"VALID_ARCHS[sdk=iphoneos7.0]" = x86_64;
 			};
 			name = Release;
 		};

--- a/SimShim/SimShim.xcodeproj/project.pbxproj
+++ b/SimShim/SimShim.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		281B9F171662CAF5000DF4AB /* SimLib.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SimLib.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		281B9F171662CAF5000DF4AB /* SimShim.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = SimShim.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		281B9F1A1662CAF5000DF4AB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		281B9F1D1662CAF5000DF4AB /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		281B9F1E1662CAF5000DF4AB /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -49,7 +49,7 @@
 		281B9F181662CAF5000DF4AB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				281B9F171662CAF5000DF4AB /* SimLib.dylib */,
+				281B9F171662CAF5000DF4AB /* SimShim.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -121,7 +121,7 @@
 			);
 			name = SimShim;
 			productName = Sim64Lib;
-			productReference = 281B9F171662CAF5000DF4AB /* SimLib.dylib */;
+			productReference = 281B9F171662CAF5000DF4AB /* SimShim.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 /* End PBXNativeTarget section */


### PR DESCRIPTION
Build ScriptAgentShim.dylib as a universal binary, so that 64-bit
simulator runs can be shimmed.
