### PR TITLE
Parameterize Target Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Build and run the test:
 ./build.sh test
 ```
 
+The simulator identifier/name can optionally be added as an argument:
+
+```
+./build.sh test D82D8D7B-5253-3300-B083-B6F739F68355
+```
+
 Under the `build` directory, you'll have a new `instruments` script.  Use it in place of `/usr/bin/instruments`.
 
 ### How it works

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 cd `dirname $0`
 
 BUILD_OUTPUT_DIR=$(echo `pwd`/build)
@@ -23,12 +24,17 @@ cp instruments $BUILD_OUTPUT_DIR/instruments
 if [[ $1 == "test" ]]; then
   TEST_JS=$(echo `pwd`/test.js)
   XCODE_PATH=$(xcode-select --print-path)
-
   OUTPUT_DIR=$(/usr/bin/mktemp -d -t trace)
+  if [[ -n $2 ]]; then
+    SIMULATOR_NAME="$2"
+  else
+    SIMULATOR_NAME="iPhone 5 (8."
+  fi
+
   pushd $OUTPUT_DIR
   $BUILD_OUTPUT_DIR/instruments \
     -t "$XCODE_PATH"/../Applications/Instruments.app/Contents/PlugIns/AutomationInstrument.*/Contents/Resources/Automation.tracetemplate \
-    -w "iPhone 5s (8." \
+    -w $SIMULATOR_NAME \
     $BUILD_OUTPUT_DIR/TestApp.app \
     -e UIASCRIPT $TEST_JS
   popd

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 set -e
-set -x
 cd `dirname $0`
 
 BUILD_OUTPUT_DIR=$(echo `pwd`/build)


### PR DESCRIPTION
Makes testing across Xcode & Simulator versions significantly easier as `build.sh` changes are not needed.