### PR TITLE
Xcode 7 SimShim Updates

### DIFF
--- a/InstrumentsShim/InstrumentsShim/InstrumentsShim.m
+++ b/InstrumentsShim/InstrumentsShim/InstrumentsShim.m
@@ -37,7 +37,9 @@ typedef struct LSApplicationParameters_V1 LSApplicationParameters_V1;
 
 id _LSOpenApplicationURL(NSURL *url, LSLaunchFlags *launchFlags, const LSApplicationParameters_V1 *appParams);
 static id __LSOpenApplicationURL(NSURL *url, LSLaunchFlags *launchFlags, LSApplicationParameters_V1 *appParams) {
-  if ([[url absoluteString] rangeOfString:@"iOS%20Simulator"].location != NSNotFound) {
+  
+  NSSet *simulatorApps = [NSSet setWithArray:@[@"iOS Simulator.app", @"Simulator.app"]];
+  if ([simulatorApps containsObject:[[url pathComponents] lastObject]]) {
     NSMutableDictionary *newEnvironment = [NSMutableDictionary dictionary];
     if (appParams->environment) {
       newEnvironment = [NSMutableDictionary dictionaryWithDictionary:appParams->environment];

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ Under the `build` directory, you'll have a new `instruments` script.  Use it in 
 ### How it works
 
 Instruments launches UIAutomation scripts in the iOS Simulator with a program called __ScriptAgent__.  Actually, Instruments launches the __iOS Simulator__, which starts up the whole Simulator environment. Eventually, __DTMobileIS__ is started up which finally starts launches __ScriptAgent__.  ScriptAgent is what actually links __UIAutomation.framework__ and runs the scripts, so we inject a library into ScriptAgent that swizzles out `performTaskWithPathArgumentsTimeout` with our own implementation that has no 1 second delay.
+
+### Xcode 7 / iOS 9 Support
+As of the time of writing, `SimShim.dylib` can't be injected into the Xcode 7 ```Simulator.app``` as there is kernel-level protection for using `DYLD_INSERT_LIBRARIES` on unsigned binaries. See [this Gist](https://gist.github.com/lawrencelomax/27bdc4e8a433a601008f) for more information. The current workaround is to inject environment variables into the `DTServiceHub` process, by using an `EnvironmentVariables` dictionary in the `com.apple.instruments.deviceservice.plist` Launch Agent. The `LIB_PATH` and `DYLD_INSERT_LIBRARIES` environment variables can be passed through here.


### PR DESCRIPTION
Updates to the `README` and `InstrumentsShim` for some of the changes in Xcode 7. Still using the workaround to insert libraries into the `DTServiceHub` process.
